### PR TITLE
Added margin and padding on user box style

### DIFF
--- a/app/assets/stylesheets/resources/users.sass
+++ b/app/assets/stylesheets/resources/users.sass
@@ -1,5 +1,6 @@
 .user-box
-  padding: 5px
+  padding: 12px 5px 5px 5px
+  margin: 0px 10px 10px 0px
   border-radius: 5px
   -webkit-border-radius: 5px
   -moz-border-radius: 5px


### PR DESCRIPTION
Removed left margin, so user boxes won't break a visual line suddenly. Now we have a four boxes row, using all of the container total width. Added margin on the bottom of the box, too.
