### PR TITLE
Happens at on event partial is displayed as long format

### DIFF
--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -1,4 +1,4 @@
 .events
   h2
     = link_to event.name, event
-    span.pull-right = l event.happens_at, format: :short
+    span.pull-right = l event.happens_at, format: :long


### PR DESCRIPTION
This is more like a suggestion. I feel that displaying the year with the event date could be important, as people who were involved with GURU-RS in the past may return to the website now and won't be sure if those events on display are recent or not. Also, it makes sure to show to everyone that we're damn active and rockin' around.
