### PR TITLE
showing dates messages for admins and no-admins

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,14 +8,15 @@ class User < ActiveRecord::Base
   validates :name, presence: true
   validates :admin_time_from, presence: true, if: :admin?
 
-  def admin_period
-    return unless admin == true
-
-    if admin_time_to.present?
-      "De #{admin_time_from} até #{admin_time_to}."
+  def member_since
+    if admin?
+      from = admin_time_from
+      to = (admin_time_to.present? ? admin_time_to : "agora")
     else
-      "De #{admin_time_from} até agora."
+      from = created_at.year
+      to = "agora"
     end
+    "De #{from} até #{to}."
   end
 
   def self.new_with_session(params, session)

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -4,7 +4,7 @@
   .name
     strong = user.name
   .admin_time
-    = user.admin_period
+    = user.member_since
   - if user.github_username.present?
     = link_to user.github_username, "http://github.com/#{user.github_username}", class: 'github-icon'
   - if user.twitter_username.present?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -82,19 +82,26 @@ describe User do
     end
   end
 
-  describe 'admin_period' do
-    before { @user = User.make!(admin: true, admin_time_from: 2010) }
+  describe 'member_since' do
+    before { @admin = User.make!(admin: true, admin_time_from: 2010) }
+    before { @no_admin = User.make!(admin: false, created_at: Date.today) }
 
-    context 'when admin_time_to is present' do
+    context 'admin user when admin_time_to is present' do
       it "should show complete message" do
-        @user.admin_time_to = Date.today.year
-        expect(@user.admin_period).to eql ("De 2010 até #{@user.admin_time_to}.")
+        @admin.admin_time_to = Date.today.year
+        expect(@admin.member_since).to eql ("De 2010 até #{@admin.admin_time_to}.")
       end
     end
 
-    context 'when admin_time_to is not present' do
+    context 'admin user when admin_time_to is not present' do
       it "should show until now" do
-        expect(@user.admin_period).to eql ("De 2010 até agora.")
+        expect(@admin.member_since).to eql ("De 2010 até agora.")
+      end
+    end
+
+    context 'simple user' do
+      it "should show the year the user was created until now" do
+        expect(@no_admin.member_since).to eql ("De #{@no_admin.created_at.year} até agora.")
       end
     end
   end


### PR DESCRIPTION
Related to https://github.com/gururs/gururs/issues/21

The way it is implemented consider that if a user isn't an admin he is part of GURU since the DB registry was created and still is part of it, otherwise if the user is an admin it behaves just like it was already doing.
I'm not sure if this is the expected solution, feel free to reject the pull request and clarify it for me =)
